### PR TITLE
Update XSSFWorkbook.cs - IsDate1904()

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -1453,6 +1453,10 @@ namespace NPOI.XSSF.UserModel
         internal bool IsDate1904()
         {
             CT_WorkbookPr workbookPr = workbook.workbookPr;
+            
+            if (workbookPr == null)
+                return false;
+                
             return workbookPr.date1904Specified && workbookPr.date1904;
         }
 


### PR DESCRIPTION
Update IsDate1904() to check for null workbookPr. 
This can occur with some computer generated xlsx documents, causing and exception to be thrown.